### PR TITLE
refactor: Replace url() with re_path()

### DIFF
--- a/dumpstermap/urls.py
+++ b/dumpstermap/urls.py
@@ -13,11 +13,12 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.conf.urls import include
 from django.contrib import admin
+from django.urls import re_path
 
 urlpatterns = [
-    url(r"^admin/", admin.site.urls),
-    url(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
-    url(r"^", include("dumpsters.urls")),
+    re_path(r"^admin/", admin.site.urls),
+    re_path(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
+    re_path(r"^", include("dumpsters.urls")),
 ]

--- a/dumpsters/urls.py
+++ b/dumpsters/urls.py
@@ -1,4 +1,5 @@
-from django.conf.urls import url, include
+from django.conf.urls import include
+from django.urls import re_path
 from rest_framework import routers
 
 from .views import *
@@ -7,4 +8,4 @@ router = routers.SimpleRouter()
 router.register(r"dumpsters", DumpsterList)
 router.register(r"votings", VotingViewSet)
 
-urlpatterns = [url(r"^", include(router.urls))]
+urlpatterns = [re_path(r"^", include(router.urls))]


### PR DESCRIPTION
In Django 4.0, django.conf.urls.url() is deprecated in favor of django.urls.re_path()

Closes #28